### PR TITLE
Reorganize types; move big endian encoding

### DIFF
--- a/src/eth1spec/base_types.py
+++ b/src/eth1spec/base_types.py
@@ -17,6 +17,24 @@ class Uint(int):
 
     __slots__ = ()
 
+    @classmethod
+    def from_be_bytes(cls: Type, buffer: "Bytes") -> "Uint":
+        """
+        Converts a sequence of bytes into an arbitrarily sized unsigned integer
+        from its big endian representation.
+
+        Parameters
+        ----------
+        buffer : `Bytes`
+            Bytes to decode.
+
+        Returns
+        -------
+        self : `Uint`
+            Unsigned integer decoded from `buffer`.
+        """
+        return cls(int.from_bytes(buffer, "big"))
+
     def __new__(cls: Type, value: int) -> "Uint":
         if not isinstance(value, int):
             raise TypeError()
@@ -195,5 +213,36 @@ class Uint(int):
 
     # TODO: Implement and, or, xor, neg, pos, abs, invert, ...
 
-    def to_big_endian(self) -> bytes:
+    def to_be_bytes32(self) -> "Bytes32":
+        """
+        Converts this arbitrarily sized unsigned integer into its big endian
+        representation with exactly 32 bytes.
+
+        Returns
+        -------
+        big_endian : `Bytes32`
+            Big endian (most significant bits first) representation.
+        """
         return self.to_bytes(32, "big")
+
+    def to_be_bytes(self) -> "Bytes":
+        """
+        Converts this arbitrarily sized unsigned integer into its big endian
+        representation.
+
+        Returns
+        -------
+        big_endian : `Bytes`
+            Big endian (most significant bits first) representation.
+        """
+        bit_length = self.bit_length()
+        byte_length = (bit_length + 7) // 8
+        return self.to_bytes(byte_length, "big")
+
+
+Bytes = bytes
+Bytes64 = Bytes
+Bytes32 = Bytes
+Bytes20 = Bytes
+Bytes8 = Bytes
+U256 = Uint

--- a/src/eth1spec/crypto.py
+++ b/src/eth1spec/crypto.py
@@ -6,8 +6,8 @@ Cryptographic Functions
 import coincurve
 import sha3
 
-from .eth_types import Bytes, Hash32, Hash64
-from .number import Uint
+from .base_types import Bytes, Uint
+from .eth_types import Hash32, Hash64
 
 
 def keccak256(buffer: Bytes) -> Hash32:
@@ -50,11 +50,11 @@ def secp256k1_recover(r: Uint, s: Uint, v: Uint, msg_hash: Hash32) -> Bytes:
 
     Parameters
     ----------
-    r : `eth1spec.number.Uint`
+    r : `eth1spec.base_types.Uint`
         TODO
-    s : `eth1spec.number.Uint`
+    s : `eth1spec.base_types.Uint`
         TODO
-    v : `eth1spec.number.Uint`
+    v : `eth1spec.base_types.Uint`
         TODO
     msg_hash : `eth1spec.eth_types.Hash32`
         Hash of the message being recovered.
@@ -64,8 +64,8 @@ def secp256k1_recover(r: Uint, s: Uint, v: Uint, msg_hash: Hash32) -> Bytes:
     public_key : `eth1spec.eth_types.Bytes`
         Recovered public key.
     """
-    r_bytes = r.to_big_endian()
-    s_bytes = s.to_big_endian()
+    r_bytes = r.to_be_bytes()
+    s_bytes = s.to_be_bytes()
 
     signature = bytearray([0] * 65)
     signature[32 - len(r_bytes) : 32] = r_bytes

--- a/src/eth1spec/eth_types.py
+++ b/src/eth1spec/eth_types.py
@@ -8,18 +8,12 @@ Types re-used throughout the specification.
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-from .number import Uint
+from .base_types import U256, Bytes, Bytes8, Bytes20, Bytes32, Bytes64, Uint
 
-Bytes = bytes
-Bytes64 = Bytes
-Bytes32 = Bytes
-Bytes20 = Bytes
-Bytes8 = Bytes
-Hash32 = Bytes
-Root = Bytes
-Hash64 = Bytes64
 Address = Bytes20
-U256 = Uint
+Root = Bytes
+Hash32 = Bytes32
+Hash64 = Bytes64
 
 Storage = Dict[Bytes32, U256]
 Bloom = Bytes32

--- a/src/eth1spec/evm/interpreter.py
+++ b/src/eth1spec/evm/interpreter.py
@@ -1,6 +1,6 @@
 """
-EVM Interpreter
-------------------------------
+Ethereum Virtual Machine (EVM) Interpreter
+------------------------------------------
 
 A straightforward interpreter that executes EVM code.
 """
@@ -35,13 +35,13 @@ def process_call(
     data : `bytes`
         Array of bytes provided to the code in `target`.
 
-    value : `eth1spec.number.Uint`
+    value : `eth1spec.base_types.Uint`
         Value to be transferred.
 
-    gas : `eth1spec.number.Uint`
+    gas : `eth1spec.base_types.Uint`
         Gas provided for the code in `target`.
 
-    depth : `eth1spec.number.Uint`
+    depth : `eth1spec.base_types.Uint`
         Number of call/contract creation environments on the call stack.
 
     env : `Environment`

--- a/src/eth1spec/spec.py
+++ b/src/eth1spec/spec.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import List, Tuple
 
 from . import crypto, evm, rlp, trie
+from .base_types import Uint
 from .eth_types import (
     EMPTY_ACCOUNT,
     TX_BASE_COST,
@@ -21,7 +22,6 @@ from .eth_types import (
     Root,
     State,
     Transaction,
-    Uint,
 )
 from .evm.interpreter import process_call
 
@@ -102,13 +102,13 @@ def apply_body(
         Current account state.
     coinbase : `eth1spec.eth_types.Address`
         Address of account which receives block reward and transaction fees.
-    block_number : `eth1spec.number.Uint`
+    block_number : `eth1spec.base_types.Uint`
         Position of the block within the chain.
-    block_gas_limit : `eth1spec.number.Uint`
+    block_gas_limit : `eth1spec.base_types.Uint`
         Initial amount of gas available for execution in this block.
-    block_time : `eth1spec.number.Uint`
+    block_time : `eth1spec.base_types.Uint`
         Time the block was produced, measured in seconds since the epoch.
-    block_difficulty : `eth1spec.number.Uint`
+    block_difficulty : `eth1spec.base_types.Uint`
         Difficulty of the block.
     transactions : `List[eth1spec.eth_types.Transaction]`
         Transactions included in the block.
@@ -118,7 +118,7 @@ def apply_body(
 
     Returns
     -------
-    gas_available : `eth1spec.number.Uint`
+    gas_available : `eth1spec.base_types.Uint`
         Remaining gas after all transactions have been executed.
     root : `eth1spec.eth_types.Root`
         State root after all transactions have been executed.
@@ -184,7 +184,7 @@ def process_transaction(
 
     Returns
     -------
-    gas_left : `eth1spec.number.Uint`
+    gas_left : `eth1spec.base_types.Uint`
         Remaining gas after execution.
     logs : `List[eth1spec.eth_types.Log]`
         Logs generated during execution.
@@ -246,7 +246,7 @@ def intrinsic_cost(tx: Transaction) -> Uint:
 
     Returns
     -------
-    verified : `eth1spec.number.Uint`
+    verified : `eth1spec.base_types.Uint`
         The intrinsic cost of the transaction.
     """
     data_cost = 0

--- a/src/eth1spec/trie.py
+++ b/src/eth1spec/trie.py
@@ -9,7 +9,8 @@ The state trie is the structure responsible for storing
 from typing import Mapping, Tuple, TypeVar, Union
 
 from . import crypto, rlp
-from .eth_types import U256, Account, Bytes, Bytes64, Receipt, Root, Uint
+from .base_types import U256, Bytes, Bytes64, Uint
+from .eth_types import Account, Receipt, Root
 
 debug = False
 verbose = False
@@ -191,7 +192,7 @@ def c(
     ----------
     J : `Mapping[Bytes, Union[Bytes, Account, Receipt, Uint]]`
         TODO
-    i : `eth1spec.number.Uint`
+    i : `eth1spec.base_types.Uint`
         TODO
 
     Returns

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,4 @@
+from eth1spec.base_types import Uint
 from eth1spec.eth_types import (
     U256,
     Address,
@@ -6,7 +7,6 @@ from eth1spec.eth_types import (
     Bytes32,
     Hash32,
     Root,
-    Uint,
 )
 
 

--- a/tests/test_base_types.py
+++ b/tests/test_base_types.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eth1spec.number import Uint
+from eth1spec.base_types import Uint
 
 
 def test_uint_new() -> None:
@@ -407,3 +407,83 @@ def test_uint_ipow_modulo() -> None:
 def test_uint_ipow_modulo_negative() -> None:
     with pytest.raises(ValueError):
         Uint(4).__ipow__(2, -3)
+
+
+def test_uint_to_be_bytes_zero() -> None:
+    encoded = Uint(0).to_be_bytes()
+    assert encoded == bytes([])
+
+
+def test_uint_to_be_bytes_one() -> None:
+    encoded = Uint(1).to_be_bytes()
+    assert encoded == bytes([1])
+
+
+def test_uint_to_be_bytes_is_big_endian() -> None:
+    encoded = Uint(0xABCD).to_be_bytes()
+    assert encoded == bytes([0xAB, 0xCD])
+
+
+def test_uint_to_be_bytes32_zero() -> None:
+    encoded = Uint(0).to_be_bytes32()
+    assert encoded == bytes([0] * 32)
+
+
+def test_uint_to_be_bytes32_one() -> None:
+    encoded = Uint(1).to_be_bytes32()
+    assert encoded == bytes([0] * 31 + [1])
+
+
+def test_uint_to_be_bytes32_max_value() -> None:
+    encoded = Uint(2 ** 256 - 1).to_be_bytes32()
+    assert encoded == bytes(
+        [
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+            0xFF,
+        ]
+    )
+
+
+def test_uint_from_be_bytes_empty() -> None:
+    value = Uint.from_be_bytes(b"")
+    assert value == 0
+
+
+def test_uint_from_be_bytes_one() -> None:
+    value = Uint.from_be_bytes(bytes([1]))
+    assert value == 1
+
+
+def test_uint_from_be_bytes_is_big_endian() -> None:
+    value = Uint.from_be_bytes(bytes([0xAB, 0xCD]))
+    assert value == 0xABCD

--- a/tests/test_rlp.py
+++ b/tests/test_rlp.py
@@ -1,6 +1,0 @@
-from eth1spec.number import Uint
-from eth1spec.rlp import BE
-
-
-def test_BE() -> None:
-    assert BE(Uint(0x123456)) == b"\x12\x34\x56"


### PR DESCRIPTION
Move the integer encoding into the `Uint` class, instead of in the RLP module. Because of the way Python modules work (i.e. no circular dependencies), that means the `Bytes` and `Bytes32` types need to be in the same file as `Uint`.