### PR TITLE
Added GitHub templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,22 @@
+* Version: x.x.x
+* Python: 2.7/3.4/3.5
+* OS: osx/linux/win
+* `pip freeze` output
+
+```
+<put the output from running pip freeze here>
+```
+
+
+### What was wrong?
+
+Please include any of the following that are applicable:
+
+* The code which produced the error
+* The full output of the error
+* What type of node you were connecting to.
+
+
+### How can it be fixed?
+
+Fill this section in if you know how this could or should be fixed.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+### What was wrong?
+
+Related to Issue #
+
+### How was it fixed?
+
+
+#### Cute Animal Picture
+
+![Put a link to a cute animal picture inside the parenthesis-->]()


### PR DESCRIPTION
### What was wrong?
This repo doesn't have GitHub templates for issues and PRs. Now that there are external contributors interested in this project, adding a brief description helps others better understand the gist of the PR/issue. We need templates that help remind developers to add a description.

### How can it be fixed?
Added GitHub templates for issues and PRs.
PS: The templates have been stolen from the `web3.py` repo.