### PR TITLE
Added a note for cloning submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ Running the tests necessary to merge into the repository requires:
 
 These version ranges are necessary because, at the time of writing, PyPy is only compatible with Python 3.7.
 
+`eth1.0-specs` depends on a submodule that contains common tests that are run across all clients, so we need to clone the repo with the --recursive flag. Example:
+```bash
+$ git clone --recursive https://github.com/quilt/eth1.0-specs.git
+```
+
+Or, if you've already cloned the repository, you can fetch the submodules with:
+
+```bash
+$ git submodule update --init --recursive
+```
+
+The tests can be run with:
 ```bash
 $ tox
 ```


### PR DESCRIPTION
### What was wrong?
running `pytest --ignore-glob='tests/fixtures/*'` resulted in the following error:
```bash
================================================================================================ FAILURES ================================================================================================
________________________________________________________________________________________________ test_add ________________________________________________________________________________________________

    def test_add() -> None:
>       run_test("stExample/add11_d0g0v0.json")

tests/test_spec.py:21:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/test_spec.py:46: in run_test
    test = load_test(base + path)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

path = 'tests/fixtures/LegacyTests/Constantinople/BlockchainTests/GeneralStateTests/stExample/add11_d0g0v0.json'

    def load_test(path: str) -> Any:
>       with open(path) as f:
E       FileNotFoundError: [Errno 2] No such file or directory: 'tests/fixtures/LegacyTests/Constantinople/BlockchainTests/GeneralStateTests/stExample/add11_d0g0v0.json'

tests/test_spec.py:27: FileNotFoundError
```
This happened because I wasn't aware that I had to clone the fixtures submodule
### How can it be fixed?
Added a note in `README.md` for cloning submodules. 