### PR TITLE
Improve templates and module/package docstrings.

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -1,5 +1,5 @@
 /* Headings */
-#module-details h3 {
+#package-details h4, #module-details h4 {
     border-bottom: 1px solid #888;
 }
 

--- a/doc/_templates/autoapi/python/class.rst
+++ b/doc/_templates/autoapi/python/class.rst
@@ -1,8 +1,5 @@
 {% if obj.display %}
 
-{{ obj.short_name }}
-{{ '~' * obj.short_name|length }}
-
 {% if obj.docstring %}
 {{ obj.docstring|prepare_docstring }}
 {% endif %}

--- a/doc/_templates/autoapi/python/function.rst
+++ b/doc/_templates/autoapi/python/function.rst
@@ -1,8 +1,5 @@
 {% if obj.display %}
 
-{{ obj.short_name }}
-{{ '~' * obj.short_name|length }}
-
 {{ obj.summary|prepare_docstring }}
 
 .. function:: {{ obj.short_name }}({{ obj.args }}){% if obj.return_annotation is not none %} -> {{ obj.return_annotation }}{% endif %}

--- a/doc/_templates/autoapi/python/module.rst
+++ b/doc/_templates/autoapi/python/module.rst
@@ -108,6 +108,12 @@ Attributes
 {{ "-" * obj.type|length }}---------
 {% endif %}
 {% for obj_item in visible_children %}
+{% if obj_item.display %}
+
+{{ obj_item.short_name }}
+{{ '~' * obj_item.short_name|length }}
+
+{% endif %}
 {{ obj_item.render()|indent(0) }}
 {% endfor %}
 {% endif %}

--- a/src/eth1spec/__init__.py
+++ b/src/eth1spec/__init__.py
@@ -1,6 +1,6 @@
 """
 Ethereum Specification
-----------------------
+^^^^^^^^^^^^^^^^^^^^^^
 
 Core specifications for Ethereum clients.
 """

--- a/src/eth1spec/base_types.py
+++ b/src/eth1spec/base_types.py
@@ -1,6 +1,15 @@
 """
 Numeric & Array Types
----------------------
+^^^^^^^^^^^^^^^^^^^^^
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+Integer and array types which are used by—but not unique to—Ethereum.
 """
 
 # flake8: noqa

--- a/src/eth1spec/crypto.py
+++ b/src/eth1spec/crypto.py
@@ -1,6 +1,15 @@
 """
 Cryptographic Functions
------------------------
+^^^^^^^^^^^^^^^^^^^^^^^
+
+..contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+Cryptographic primatives used in—but not defined by—the Ethereum specification.
 """
 
 import coincurve

--- a/src/eth1spec/eth_types.py
+++ b/src/eth1spec/eth_types.py
@@ -1,8 +1,15 @@
 """
-Base Types
-----------
+Ethereum Types
+^^^^^^^^^^^^^^
 
-Types re-used throughout the specification.
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass

--- a/src/eth1spec/evm/__init__.py
+++ b/src/eth1spec/evm/__init__.py
@@ -1,6 +1,13 @@
 """
 Ethereum Virtual Machine (EVM)
-------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
 
 The abstract computer which runs the code stored in an
 `eth1spec.eth_types.Account`.

--- a/src/eth1spec/evm/error.py
+++ b/src/eth1spec/evm/error.py
@@ -1,6 +1,15 @@
 """
-EVM Runtime Errors
-------------------
+Ethereum Virtual Machine (EVM) Errors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+Errors which cause the EVM to halt exceptionally.
 """
 
 

--- a/src/eth1spec/evm/gas.py
+++ b/src/eth1spec/evm/gas.py
@@ -1,6 +1,17 @@
 """
-EVM Gas Constants and Calculators
+Ethereum Virtual Machine (EVM) Gas
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+EVM gas constants and calculators.
 """
+
 from ..base_types import U256
 from .error import OutOfGasError
 

--- a/src/eth1spec/evm/instructions.py
+++ b/src/eth1spec/evm/instructions.py
@@ -1,6 +1,15 @@
 """
-EVM Instructions
-----------------------
+Ethereum Virtual Machine (EVM) Instructions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+Implementations of the instructions understood by the EVM.
 """
 
 

--- a/src/eth1spec/evm/interpreter.py
+++ b/src/eth1spec/evm/interpreter.py
@@ -1,6 +1,13 @@
 """
 Ethereum Virtual Machine (EVM) Interpreter
-------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
 
 A straightforward interpreter that executes EVM code.
 """

--- a/src/eth1spec/evm/ops.py
+++ b/src/eth1spec/evm/ops.py
@@ -1,6 +1,13 @@
 """
 Instruction Encoding (Opcodes)
-------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
 
 Machine readable representations of EVM instructions, and a mapping to their
 implementations.

--- a/src/eth1spec/evm/stack.py
+++ b/src/eth1spec/evm/stack.py
@@ -1,6 +1,15 @@
 """
-EVM Stack Operators
-----------------------
+Ethereum Virtual Machine (EVM) Stack
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+Implementation of the stack operators for the EVM.
 """
 
 from typing import List

--- a/src/eth1spec/rlp.py
+++ b/src/eth1spec/rlp.py
@@ -1,6 +1,15 @@
 """
 Recursive Length Prefix (RLP) Encoding
---------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+Defines the serialization and deserialization format used throughout Ethereum.
 """
 
 from __future__ import annotations

--- a/src/eth1spec/spec.py
+++ b/src/eth1spec/spec.py
@@ -1,6 +1,15 @@
 """
 Ethereum Specification
-----------------------
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+Entry point for the Ethereum specification.
 """
 
 from dataclasses import dataclass

--- a/src/eth1spec/trie.py
+++ b/src/eth1spec/trie.py
@@ -1,6 +1,13 @@
 """
 State Trie
-----------
+^^^^^^^^^^
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
 
 The state trie is the structure responsible for storing
 `eth1spec.eth_types.Account` objects.


### PR DESCRIPTION
This PR makes the templates/docstrings a bit closer to how the eth2.0 specs are organized (inspired by @voith's comments on discord):

 - Add table of contents to each module/package.
 - Add an extra header level so that things are better organized.
 - Hoist headers so that attributes also show up in TOCs.
 - Fix underline CSS for children of packages.