### PR TITLE
Verify transaction root and ommers hash in header before state transitioning

### DIFF
--- a/src/eth1spec/rlp.py
+++ b/src/eth1spec/rlp.py
@@ -20,7 +20,18 @@ from .base_types import U256, Bytes, Uint
 from .crypto import keccak256
 from .eth_types import Account, Block, Header, Log, Receipt, Transaction
 
-RLP = Union[Bytes, Uint, U256, Sequence["RLP"]]  # type: ignore
+RLP = Union[  # type: ignore
+    Bytes,
+    Uint,
+    U256,
+    Block,
+    Header,
+    Account,
+    Transaction,
+    Receipt,
+    Log,
+    Sequence["RLP"],  # type: ignore
+]
 
 
 #

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+from eth1spec import crypto, rlp
 from eth1spec.base_types import Uint
 from eth1spec.eth_types import (
     U256,
@@ -27,7 +30,7 @@ def hex2bytes8(x: str) -> Bytes8:
 
 
 def hex2bytes32(x: str) -> Bytes32:
-    return Bytes32(bytes.fromhex(remove_hex_prefix(x)))
+    return Bytes32(bytes.fromhex(remove_hex_prefix(x).rjust(64, "0")))
 
 
 def hex2hash(x: str) -> Hash32:
@@ -58,3 +61,7 @@ def remove_hex_prefix(x: str) -> str:
     if has_hex_prefix(x):
         return x[len("0x") :]
     return x
+
+
+def rlp_hash(x: Any) -> Bytes:
+    return crypto.keccak256(rlp.encode(x))

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,9 +1,11 @@
 import json
 import os
-from typing import Any, List
+from typing import Any, List, cast
 
+from eth1spec import rlp
+from eth1spec.base_types import U256
 from eth1spec.eth_types import Account, Block, Header, State, Transaction
-from eth1spec.spec import BlockChain, state_transition
+from eth1spec.spec import BlockChain, print_state, state_transition
 
 from .helpers import (
     hex2address,
@@ -14,12 +16,12 @@ from .helpers import (
     hex2root,
     hex2u256,
     hex2uint,
+    rlp_hash,
 )
 
 
 def test_add() -> None:
     run_test("stExample/add11_d0g0v0.json")
-    print("done")
 
 
 # loads a blockchain test
@@ -45,26 +47,49 @@ def run_test(path: str) -> None:
 
     test = load_test(base + path)
 
+    genesis_header = json_to_header(test.get("genesisBlockHeader"))
     genesis = Block(
-        json_to_header(test.get("genesisBlockHeader")),
+        genesis_header,
         [],
         [],
     )
 
+    assert rlp_hash(genesis_header) == hex2bytes(
+        test["genesisBlockHeader"]["hash"]
+    )
+    assert rlp.encode(cast(rlp.RLP, genesis)) == hex2bytes(
+        test.get("genesisRLP")
+    )
+
     pre_state = json_to_state(test.get("pre"))
-    # post_state = json_to_state(test.get("post"))
+    expected_post_state = json_to_state(test.get("postState"))
 
     chain = BlockChain(
         blocks=[genesis],
         state=pre_state,
     )
 
+    block_obj = None
     for block in test.get("blocks"):
         header = json_to_header(block.get("blockHeader"))
-        txs = list(map(json_to_tx, block.get("transactions")))
-        ommers: List[Header] = []  # TODO
+        txs: List[Transaction] = [
+            json_to_tx(tx_json) for tx_json in block.get("transactions")
+        ]
+        ommers: List[Header] = [
+            json_to_header(ommer_json)
+            for ommer_json in block.get("uncleHeaders")
+        ]
 
-        state_transition(chain, Block(header, txs, ommers))
+        assert rlp_hash(header) == hex2bytes(block["blockHeader"]["hash"])
+        block_obj = Block(header, txs, ommers)
+        assert rlp.encode(cast(rlp.RLP, block_obj)) == hex2bytes(block["rlp"])
+
+        state_transition(chain, block_obj)
+
+    last_block_hash = rlp_hash(chain.blocks[-1].header)
+    assert last_block_hash == hex2bytes(test["lastblockhash"])
+
+    assert chain.state == expected_post_state
 
 
 def json_to_header(raw: Any) -> Header:
@@ -103,17 +128,18 @@ def json_to_tx(raw: Any) -> Transaction:
 
 def json_to_state(raw: Any) -> State:
     state = {}
-    for (addr, vals) in raw.items():
+    for (addr, acc_state) in raw.items():
         account = Account(
-            nonce=hex2uint(vals.get("nonce", "0x0")),
-            balance=hex2uint(vals.get("balance", "0x0")),
-            code=hex2bytes(vals.get("code", "")),
+            nonce=hex2uint(acc_state.get("nonce", "0x0")),
+            balance=hex2uint(acc_state.get("balance", "0x0")),
+            code=hex2bytes(acc_state.get("code", "")),
             storage={},
         )
 
-        # TODO: Load storage from json (be sure to strip leading 0s of value)
-        #  for (k, v) in vals.get("storage", {}).items():
-        #      account.storage[hex2bytes32(k)] = b"\x02"  # hex2bytes32(v)
+        for (k, v) in acc_state.get("storage", {}).items():
+            account.storage[hex2bytes32(k)] = U256.from_be_bytes(
+                hex2bytes32(v)
+            )
 
         state[hex2address(addr)] = account
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -52,6 +52,7 @@ dest
 fromhex
 preimage
 substring
+klass
 
 sha3
 


### PR DESCRIPTION
	- Improve tests so that it verifies rlp and hash values for
	  blocks and headers
	- Verify state post state transition by blocks

### What was wrong?
Transaction Root and Ommers hash weren't being verified before state transitioning. This PR fixes that.
Related to Issue #12 

### How was it fixed?
Fixed based on Trie implementation

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://imgs.abduzeedo.com/files/articles/baby-animals/Baby-Animals-007.jpg)
