### PR TITLE
Hide docstrings in included source code

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -8,6 +8,10 @@ pre, .class, .function {
     font-size: 13px;
 }
 
+pre {
+    padding: 1.5em;
+}
+
 /* Classes */
 .class {
     background: #d5d5ee;
@@ -15,7 +19,7 @@ pre, .class, .function {
 }
 
 /* Functions */
-.function {
+.function .sig {
     background: #d0eed0;
     padding: 1.5em;
     margin: 1em 0;

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -18,6 +18,7 @@ pre, .class, .function {
 .function {
     background: #d0eed0;
     padding: 1.5em;
+    margin: 1em 0;
 }
 
 /* Improve function signatures with type hints */
@@ -29,6 +30,11 @@ pre, .class, .function {
 .sig-param::before {
     content: '\A    ';
     white-space: pre;
+}
+
+/* Prefer increasing width in field lists over wrapping */
+dl.field-list > dt {
+    word-break: normal;
 }
 
 .sig-param + .sig-paren::before {

--- a/doc/_templates/autoapi/python/function.rst
+++ b/doc/_templates/autoapi/python/function.rst
@@ -4,8 +4,6 @@
 #}
 {% if obj.display %}
 
-{{ obj.docstring|prepare_docstring }}
-
 .. function:: {{ obj.short_name }}({{ obj.args }}){% if obj.return_annotation is not none %} -> {{ obj.return_annotation }}{% endif %}
 
    :noindexentry:
@@ -19,8 +17,12 @@
    {% endfor %}
    {% endif %}
 
-
+   {% if obj.docstring %}
+   {{ obj.docstring|prepare_docstring|indent(3) }}
+   {% else %}
+   {% endif %}
 {% endif %}
+
 
 {% set suffix = 1 + obj.obj.name|length %}
 {% set module_name = obj.obj.full_name[:-suffix] %}

--- a/doc/_templates/autoapi/python/function.rst
+++ b/doc/_templates/autoapi/python/function.rst
@@ -4,7 +4,7 @@
 #}
 {% if obj.display %}
 
-{{ obj.summary|prepare_docstring }}
+{{ obj.docstring|prepare_docstring }}
 
 .. function:: {{ obj.short_name }}({{ obj.args }}){% if obj.return_annotation is not none %} -> {{ obj.return_annotation }}{% endif %}
 
@@ -26,6 +26,6 @@
 {% set module_name = obj.obj.full_name[:-suffix] %}
 {% set module = obj.app.env.autoapi_objects[module_name] %}
 
-.. literalinclude:: /../src/{{ module.obj.relative_path }}
+.. undocinclude:: /../src/{{ module.obj.relative_path }}
    :language: {{ module.language }}
    :lines: {{ obj.obj.from_line_no }}-{{ obj.obj.to_line_no }}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,7 +21,6 @@ project = 'Ethereum Specification'
 copyright = '2021, Ethereum'
 author = 'Ethereum'
 
-
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -32,6 +31,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.autodoc',
     'autoapi.extension',
+    'undocinclude.extension',
 ]
 
 autoapi_type = 'python'

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ lint =
 
 doc =
     sphinx-autoapi>=1.8.1,<2
+    undocinclude>=0.1.1,<0.2
     sphinx==4.0.2
 
 [flake8]

--- a/src/eth1spec/base_types.py
+++ b/src/eth1spec/base_types.py
@@ -34,7 +34,7 @@ class Uint(int):
 
         Parameters
         ----------
-        buffer : `Bytes`
+        buffer :
             Bytes to decode.
 
         Returns
@@ -267,7 +267,7 @@ class U256(int):
 
         Parameters
         ----------
-        buffer : `Bytes`
+        buffer :
             Bytes to decode.
 
         Returns

--- a/src/eth1spec/crypto.py
+++ b/src/eth1spec/crypto.py
@@ -25,7 +25,7 @@ def keccak256(buffer: Bytes) -> Hash32:
 
     Parameters
     ----------
-    buffer : `eth1spec.eth_types.Bytes`
+    buffer :
         Input for the hashing function.
 
     Returns
@@ -42,7 +42,7 @@ def keccak512(buffer: Bytes) -> Hash64:
 
     Parameters
     ----------
-    buffer : `eth1spec.eth_types.Bytes`
+    buffer :
         Input for the hashing function.
 
     Returns
@@ -59,13 +59,13 @@ def secp256k1_recover(r: U256, s: U256, v: U256, msg_hash: Hash32) -> Bytes:
 
     Parameters
     ----------
-    r : `eth1spec.base_types.Uint`
+    r :
         TODO
-    s : `eth1spec.base_types.Uint`
+    s :
         TODO
-    v : `eth1spec.base_types.Uint`
+    v :
         TODO
-    msg_hash : `eth1spec.eth_types.Hash32`
+    msg_hash :
         Hash of the message being recovered.
 
     Returns

--- a/src/eth1spec/crypto.py
+++ b/src/eth1spec/crypto.py
@@ -70,7 +70,7 @@ def secp256k1_recover(r: U256, s: U256, v: U256, msg_hash: Hash32) -> Bytes:
 
     Returns
     -------
-    public_key : `eth1spec.eth_types.Bytes`
+    public_key : `eth1spec.base_types.Bytes`
         Recovered public key.
     """
     r_bytes = r.to_be_bytes32()

--- a/src/eth1spec/evm/gas.py
+++ b/src/eth1spec/evm/gas.py
@@ -24,9 +24,9 @@ def subtract_gas(gas_left: U256, amount: U256) -> U256:
 
     Parameters
     ----------
-    gas_left : `eth1spec.base_types.U256`
+    gas_left :
         The amount of gas left in the current frame.
-    amount : `eth1spec.base_types.U256`
+    amount :
         The amount of gas the current operation requires.
 
     Raises

--- a/src/eth1spec/evm/instructions.py
+++ b/src/eth1spec/evm/instructions.py
@@ -26,7 +26,7 @@ def add(evm: Evm) -> None:
 
     Parameters
     ----------
-    evm : `Evm`
+    evm :
         The current EVM frame.
 
     Raises
@@ -52,7 +52,7 @@ def sstore(evm: Evm) -> None:
 
     Parameters
     ----------
-    evm : `Evm`
+    evm :
         The current EVM frame.
 
     Raises
@@ -76,7 +76,7 @@ def push1(evm: Evm) -> None:
 
     Parameters
     ----------
-    evm : `Evm`
+    evm :
         The current EVM frame.
 
     Raises

--- a/src/eth1spec/evm/interpreter.py
+++ b/src/eth1spec/evm/interpreter.py
@@ -34,25 +34,25 @@ def process_call(
 
     Parameters
     ----------
-    caller : `eth1spec.eth_types.Address`
+    caller :
         Account which initiated this call.
 
-    target : `eth1spec.eth_types.Address`
+    target :
         Account whose code will be executed.
 
-    data : `bytes`
+    data :
         Array of bytes provided to the code in `target`.
 
-    value : `eth1spec.base_types.Uint`
+    value :
         Value to be transferred.
 
-    gas : `eth1spec.base_types.Uint`
+    gas :
         Gas provided for the code in `target`.
 
-    depth : `eth1spec.base_types.Uint`
+    depth :
         Number of call/contract creation environments on the call stack.
 
-    env : `Environment`
+    env :
         External items required for EVM execution.
 
     Returns

--- a/src/eth1spec/evm/stack.py
+++ b/src/eth1spec/evm/stack.py
@@ -14,7 +14,7 @@ Implementation of the stack operators for the EVM.
 
 from typing import List
 
-from ..eth_types import U256
+from ..base_types import U256
 from .error import StackOverflowError, StackUnderflowError
 
 

--- a/src/eth1spec/evm/stack.py
+++ b/src/eth1spec/evm/stack.py
@@ -24,7 +24,7 @@ def pop(stack: List[U256]) -> U256:
 
     Parameters
     ----------
-    stack : `List[U256]`
+    stack :
         EVM stack.
 
     Returns
@@ -49,10 +49,10 @@ def push(stack: List[U256], value: U256) -> None:
 
     Parameters
     ----------
-    stack : `List[U256]`
+    stack :
         EVM stack.
 
-    value : `U256`
+    value :
         Item to be pushed onto `stack`.
 
     Raises

--- a/src/eth1spec/rlp.py
+++ b/src/eth1spec/rlp.py
@@ -16,8 +16,7 @@ from __future__ import annotations
 
 from typing import List, Sequence, Union, cast
 
-from .base_types import U256, Uint
-from .eth_types import Bytes
+from .base_types import U256, Bytes, Uint
 
 RLP = Union[Bytes, Uint, U256, Sequence["RLP"]]  # type: ignore
 
@@ -39,7 +38,7 @@ def encode(raw_data: RLP) -> Bytes:
 
     Returns
     -------
-    encoded : `eth1spec.eth_types.Bytes`
+    encoded : `eth1spec.base_types.Bytes`
         The RLP encoded bytes representing `raw_data`.
     """
     if isinstance(raw_data, (bytearray, bytes)):
@@ -67,7 +66,7 @@ def encode_bytes(raw_bytes: Bytes) -> Bytes:
 
     Returns
     -------
-    encoded : `eth1spec.eth_types.Bytes`
+    encoded : `eth1spec.base_types.Bytes`
         The RLP encoded bytes representing `raw_bytes`.
     """
     len_raw_data = Uint(len(raw_bytes))
@@ -97,7 +96,7 @@ def encode_sequence(raw_sequence: Sequence[RLP]) -> Bytes:
 
     Returns
     -------
-    encoded : `eth1spec.eth_types.Bytes`
+    encoded : `eth1spec.base_types.Bytes`
         The RLP encoded bytes representing `raw_sequence`.
     """
     joined_encodings = get_joined_encodings(raw_sequence)
@@ -126,7 +125,7 @@ def get_joined_encodings(raw_sequence: Sequence[RLP]) -> Bytes:
 
     Returns
     -------
-    joined_encodings : `eth1spec.eth_types.Bytes`
+    joined_encodings : `eth1spec.base_types.Bytes`
         The concatenated RLP encoded bytes for each item in sequence
         raw_sequence.
     """
@@ -183,7 +182,7 @@ def decode_to_bytes(encoded_bytes: Bytes) -> Bytes:
 
     Returns
     -------
-    decoded : `eth1spec.eth_types.Bytes`
+    decoded : `eth1spec.base_types.Bytes`
         RLP decoded Bytes data
     """
     if len(encoded_bytes) == 1 and encoded_bytes[0] < 0x80:

--- a/src/eth1spec/rlp.py
+++ b/src/eth1spec/rlp.py
@@ -33,7 +33,7 @@ def encode(raw_data: RLP) -> Bytes:
 
     Parameters
     ----------
-    raw_data : `RLP`
+    raw_data :
         A `Bytes`, `Uint`, `Uint256` or sequence of `RLP` encodable
         objects.
 
@@ -62,7 +62,7 @@ def encode_bytes(raw_bytes: Bytes) -> Bytes:
 
     Parameters
     ----------
-    raw_bytes : `eth1spec.eth_types.Bytes`
+    raw_bytes :
         Bytes to encode with RLP.
 
     Returns
@@ -92,7 +92,7 @@ def encode_sequence(raw_sequence: Sequence[RLP]) -> Bytes:
 
     Parameters
     ----------
-    raw_sequence : `Sequence[RLP]`
+    raw_sequence :
             Sequence of RLP encodable objects.
 
     Returns
@@ -121,7 +121,7 @@ def get_joined_encodings(raw_sequence: Sequence[RLP]) -> Bytes:
 
     Parameters
     ----------
-    raw_sequence : `Sequence[RLP]`
+    raw_sequence :
         Sequence to encode with RLP.
 
     Returns
@@ -149,7 +149,7 @@ def decode(encoded_data: Bytes) -> RLP:
 
     Parameters
     ----------
-    encoded_data : `eth1spec.eth_types.Bytes`
+    encoded_data :
         A sequence of bytes, in RLP form.
 
     Returns
@@ -178,7 +178,7 @@ def decode_to_bytes(encoded_bytes: Bytes) -> Bytes:
 
     Parameters
     ----------
-    encoded_bytes : `eth1spec.eth_types.Bytes`
+    encoded_bytes :
         RLP encoded byte stream.
 
     Returns
@@ -218,7 +218,7 @@ def decode_to_sequence(encoded_sequence: Bytes) -> List[RLP]:
 
     Parameters
     ----------
-    encoded_sequence : `eth1spec.eth_types.Bytes`
+    encoded_sequence :
         An RLP encoded Sequence.
 
     Returns
@@ -258,7 +258,7 @@ def decode_joined_encodings(joined_encodings: Bytes) -> List[RLP]:
 
     Parameters
     ----------
-    joined_encodings : `eth1spec.eth_types.Bytes`
+    joined_encodings :
         concatenation of RLP encoded objects
 
     Returns
@@ -296,7 +296,7 @@ def decode_item_length(encoded_data: Bytes) -> int:
 
     Parameters
     ----------
-    encoded_data : `eth1spec.eth_types.Bytes`
+    encoded_data :
         RLP encoded data for a sequence of objects.
 
     Returns

--- a/src/eth1spec/spec.py
+++ b/src/eth1spec/spec.py
@@ -53,9 +53,9 @@ def state_transition(chain: BlockChain, block: Block) -> None:
 
     Parameters
     ----------
-    chain : `eth1spec.eth_types.BlockChain`
+    chain :
         History and current state.
-    block : `eth1spec.eth_types.Block`
+    block :
         Block to apply to `chain`.
     """
     #  assert verify_header(block.header)
@@ -81,7 +81,7 @@ def verify_header(header: Header) -> bool:
 
     Parameters
     ----------
-    header : `eth1spec.eth_types.Header`
+    header :
         Header to check for correctness.
 
     Returns
@@ -107,21 +107,21 @@ def apply_body(
 
     Parameters
     ----------
-    state : `eth1spec.eth_types.State`
+    state :
         Current account state.
-    coinbase : `eth1spec.eth_types.Address`
+    coinbase :
         Address of account which receives block reward and transaction fees.
-    block_number : `eth1spec.base_types.Uint`
+    block_number :
         Position of the block within the chain.
-    block_gas_limit : `eth1spec.base_types.Uint`
+    block_gas_limit :
         Initial amount of gas available for execution in this block.
-    block_time : `eth1spec.base_types.U256`
+    block_time :
         Time the block was produced, measured in seconds since the epoch.
-    block_difficulty : `eth1spec.base_types.Uint`
+    block_difficulty :
         Difficulty of the block.
-    transactions : `List[eth1spec.eth_types.Transaction]`
+    transactions :
         Transactions included in the block.
-    ommers : `List[eth1spec.eth_types.Header]`
+    ommers :
         Headers of ancestor blocks which are not direct parents (formerly
         uncles.)
 
@@ -189,9 +189,9 @@ def process_transaction(
 
     Parameters
     ----------
-    env : `eth1spec.evm.Environment`
+    env :
         Environment for the Ethereum Virtual Machine.
-    tx : `eth1spec.eth_types.Transaction`
+    tx :
         Transaction to execute.
 
     Returns
@@ -235,7 +235,7 @@ def validate_transaction(tx: Transaction) -> bool:
 
     Parameters
     ----------
-    tx : `eth1spec.eth_types.Transaction`
+    tx :
         Transaction to validate.
 
     Returns
@@ -253,7 +253,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
 
     Parameters
     ----------
-    tx : `eth1spec.eth_types.Transaction`
+    tx :
         Transaction to compute the intrinsic cost of.
 
     Returns
@@ -278,7 +278,7 @@ def recover_sender(tx: Transaction) -> Address:
 
     Parameters
     ----------
-    tx : `eth1spec.eth_types.Transaction`
+    tx :
         Transaction of interest.
 
     Returns
@@ -311,7 +311,7 @@ def signing_hash(tx: Transaction) -> Hash32:
 
     Parameters
     ----------
-    tx : `eth1spec.eth_types.Transaction`
+    tx :
         Transaction of interest.
 
     Returns
@@ -339,7 +339,7 @@ def print_state(state: State) -> None:
 
     Parameters
     ----------
-    state : `eth1spec.eth_types.State`
+    state :
         Ethereum state.
     """
     nice = {}

--- a/src/eth1spec/trie.py
+++ b/src/eth1spec/trie.py
@@ -34,15 +34,13 @@ def nibble_list_to_compact(x: Bytes, terminal: bool) -> bytearray:
     encoded in high nibble of the highest byte. The flag nibble can be broken
     down into two two-bit flags.
 
-    Highest nibble:
+    Highest nibble::
 
-    ```
-    +---+---+----------+--------+
-    | _ | _ | terminal | parity |
-    +---+---+----------+--------+
-      3   2      1         0
+        +---+---+----------+--------+
+        | _ | _ | terminal | parity |
+        +---+---+----------+--------+
+          3   2      1         0
 
-    ```
 
     The lowest bit of the nibble encodes the parity of the length of the
     remaining nibbles -- `0` when even and `1` when odd. The second lowest bit
@@ -51,9 +49,9 @@ def nibble_list_to_compact(x: Bytes, terminal: bool) -> bytearray:
 
     Parameters
     ----------
-    x : `eth1spec.eth_types.Bytes`
+    x :
         Array of nibbles.
-    terminal : `bool`
+    terminal :
         Flag denoting if the key points to a terminal (leaf) node.
 
     Returns
@@ -83,14 +81,14 @@ def map_keys(
 
     Parameters
     ----------
-    obj : `Dict[Bytes, T]`
+    obj :
         Underlying trie key-value pairs.
-    secured : `bool`
+    secured :
         Denotes whether the keys should be hashed. Defaults to `true`.
 
     Returns
     -------
-    out : `Mapping[Bytes, T]`
+    out :
         Object with keys mapped to nibble-byte form.
     """
     mapped: MutableMapping[Bytes, Node] = {}
@@ -129,7 +127,7 @@ def root(obj: Mapping[Bytes, Node]) -> Root:
 
     Parameters
     ----------
-    obj : `Mapping[Bytes, Union[Bytes, Account, Receipt, Uint, U256]]`
+    obj :
         Underlying trie key-value pairs.
 
     Returns
@@ -148,9 +146,9 @@ def node_cap(obj: Mapping[Bytes, Node], i: Uint) -> rlp.RLP:
 
     Parameters
     ----------
-    obj : `Mapping[Bytes, Union[Bytes, Account, Receipt, Uint, U256]]`
+    obj :
         Underlying trie key-value pairs.
-    i : `eth1spec.eth_types.U256`
+    i :
         Current trie level.
 
     Returns
@@ -177,9 +175,9 @@ def patricialize(obj: Mapping[Bytes, Node], i: Uint) -> rlp.RLP:
 
     Parameters
     ----------
-    obj : `Mapping[Bytes, Union[Bytes, Account, Receipt, Uint, U256]]`
+    obj :
         Underlying trie key-value pairs.
-    i : `eth1spec.eth_types.Uint`
+    i :
         Current trie level.
 
     Returns

--- a/src/eth1spec/trie.py
+++ b/src/eth1spec/trie.py
@@ -88,7 +88,7 @@ def map_keys(
 
     Returns
     -------
-    out :
+    out : `Mapping[eth1spec.base_types.Bytes, Node]`
         Object with keys mapped to nibble-byte form.
     """
     mapped: MutableMapping[Bytes, Node] = {}
@@ -182,7 +182,7 @@ def patricialize(obj: Mapping[Bytes, Node], i: Uint) -> rlp.RLP:
 
     Returns
     -------
-    node : `eth1spec.eth_types.Bytes`
+    node : `eth1spec.base_types.Bytes`
         Root node of `obj`.
     """
     if len(obj) == 0:


### PR DESCRIPTION
### What was wrong?

Closes #26, plus assorted other small documentation fixes.

Also, documenting the types of parameters is redundant, so removed all that. Have to still document return types or else it doesn't parse correctly.

### How was it fixed?

Created a hacked `literalinclude` directive that parses and excludes docstrings.

#### Cute Animal Picture

![Dungeon Master Kitty](https://i.imgur.com/2uRlUyB.jpg)
