### PR TITLE
Create a tox command for live preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ $ tox -e doc
 
 The path to the generated HTML will be printed to the console.
 
+#### Live Preview
+
+A live preview of the documentation can be viewed locally on port `8000` with the following command:
+
+```bash
+$ tox -e doc-autobuild
+```
+
 ### Development
 
 Running the tests necessary to merge into the repository requires:

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,9 @@ doc =
     undocinclude>=0.1.1,<0.2
     sphinx==4.0.2
 
+doc-autobuild =
+    sphinx-autobuild==2021.3.14
+
 [flake8]
 dictionaries=en_US,python,technical
 docstring-convention = all

--- a/tox.ini
+++ b/tox.ini
@@ -27,3 +27,11 @@ extras = doc
 commands =
     sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
     python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
+
+[testenv:doc-autobuild]
+basepython = python3
+extras =
+    doc
+    doc-autobuild
+commands =
+    sphinx-autobuild doc --watch src "{toxworkdir}/docs_out" {posargs}


### PR DESCRIPTION
closes #20 

Live previews can now be spun up with `tox -e doc-autobuild`.