### PR TITLE
Add step to build docs in ci

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,3 +32,6 @@ jobs:
         with:
           files: .tox/coverage.xml
           flags: unittests
+      - name: Build docs
+        if: ${{ matrix.python != 'pypy-3.7' }}
+        run: tox -e doc

--- a/doc/_templates/autoapi/python/function.rst
+++ b/doc/_templates/autoapi/python/function.rst
@@ -29,5 +29,5 @@
 {% set module = obj.app.env.autoapi_objects[module_name] %}
 
 .. undocinclude:: /../src/{{ module.obj.relative_path }}
-   :language: {{ module.language }}
+   :anguage: {{ module.language }}
    :lines: {{ obj.obj.from_line_no }}-{{ obj.obj.to_line_no }}

--- a/doc/_templates/autoapi/python/function.rst
+++ b/doc/_templates/autoapi/python/function.rst
@@ -29,5 +29,5 @@
 {% set module = obj.app.env.autoapi_objects[module_name] %}
 
 .. undocinclude:: /../src/{{ module.obj.relative_path }}
-   :anguage: {{ module.language }}
+   :language: {{ module.language }}
    :lines: {{ obj.obj.from_line_no }}-{{ obj.obj.to_line_no }}


### PR DESCRIPTION
closes #53 

Failures in the documentation building process should now stop a PR from being mergeable.